### PR TITLE
API_CreateKeyPair to publish the location of private key pair file is…

### DIFF
--- a/pages/EC-EC2_help.xml
+++ b/pages/EC-EC2_help.xml
@@ -411,8 +411,12 @@
 
     <h2>API_CreateKey</h2>
 
-    <p>This procedure creates a new key pair with the specified name. The public key is stored by Amazon EC2, and the private key is 
-		returned to you. If a key with the specified name already exists, Amazon EC2 returns an error.</p>
+    <p>This procedure creates a new key pair with the specified name. If a key with the specified name already exists, Amazon EC2 returns an error.
+        The public key is stored by Amazon EC2, and the private key file is saved in the job workspace with read permission for the user running the agent.
+        The private key file name is the key pair name, with <i>.pem</i> as extension.
+        <br/><b>Important:</b> You should retrieve the private key file from the job workspace and save it in a secure place.
+        You will need the private key file in order to connect (using SSH or Windows Remote Desktop) to any EC2 instance that was launched using
+        the key pair name.</p>
 		
 		<h3>Input</h3>
 						

--- a/src/main/resources/project/postpExtension.pl
+++ b/src/main/resources/project/postpExtension.pl
@@ -32,8 +32,8 @@ push (@::gMatchers,
 push (@::gMatchers, 
     {
         id =>              "Amazon Key Pair Create",
-        pattern =>          q{KeyPair (.*) created},
-        action =>           q{addToSummary("KeyPair $1 created");},
+        pattern =>          q{KeyPair (.*) created at (.*)},
+        action =>           q{addToSummary("KeyPair $1 created at $2");},
     },
 );
 

--- a/src/main/resources/project/project.xml
+++ b/src/main/resources/project/project.xml
@@ -4819,7 +4819,7 @@
         </procedure>
         <procedure>
             <procedureName>API_CreateKey</procedureName>
-            <description>Create a key pair</description>
+            <description>Creates a key pair using Amazon EC2.</description>
             <jobNameTemplate>EC2-createKey-$[jobId]</jobNameTemplate>
             <resourceName/>
             <workspaceName>default</workspaceName>
@@ -5199,6 +5199,7 @@
                 <description/>
                 <required>1</required>
                 <type>entry</type>
+                <expansionDeferred>1</expansionDeferred>
             </formalParameter>
             <formalParameter>
                 <formalParameterName>propResult</formalParameterName>

--- a/src/main/resources/project/ui_forms/API_DeleteVolume.xml
+++ b/src/main/resources/project/ui_forms/API_DeleteVolume.xml
@@ -9,7 +9,7 @@
     </formElement>
     <formElement>
         <type>checkbox</type>
-        <label>Detach Only?:</label>
+        <label>Detach Only?</label>
         <property>detachOnly</property>
         <required>1</required>
         <checkedValue>1</checkedValue>

--- a/src/main/resources/project/ui_forms/API_RunInstances.xml
+++ b/src/main/resources/project/ui_forms/API_RunInstances.xml
@@ -159,7 +159,7 @@
     </formElement>
     <formElement>
         <type>checkbox</type>
-        <label>Use Private IP for subnet?:</label>
+        <label>Use Private IP for subnet?</label>
         <property>use_private_ip</property>
         <required>0</required>
         <checkedValue>1</checkedValue>

--- a/src/main/resources/project/ui_forms/EC2CreateConfigForm.xml
+++ b/src/main/resources/project/ui_forms/EC2CreateConfigForm.xml
@@ -50,7 +50,7 @@
     </formElement>
     <formElement>
         <type>checkbox</type>
-        <label>Attempt Connection?:</label>
+        <label>Attempt Connection?</label>
         <property>attempt</property>
         <checkedValue>1</checkedValue>
         <uncheckedValue>0</uncheckedValue>

--- a/src/main/resources/project/ui_forms/EC2EditConfigForm.xml
+++ b/src/main/resources/project/ui_forms/EC2EditConfigForm.xml
@@ -38,7 +38,7 @@
     </formElement>
     <formElement>
         <type>checkbox</type>
-        <label>Attempt Connection?:</label>
+        <label>Attempt Connection?</label>
         <property>attempt</property>
         <checkedValue>1</checkedValue>
         <uncheckedValue>0</uncheckedValue>


### PR DESCRIPTION
… saved

o API_CreateKeyPair updates to publish the location where the private
key pair file is saved.
o Updated logs and documentation to provide note to the user to secure
the private key pair file.
o Changed the permissions on the private key pair file to read nly for
the agent user. No other user can access the file.
This is in line with the recommendation that Amazon EC2 provides for the
private key pair file. Currently EC-EC2 plugin does not have specific
use-cases where the generated key pair file is used by other procedures
so we do not want to make any further enhancements to how the file is
handled.
