### PR TITLE
Configuring the EC2 plugin to include the AWS jar for use with Create…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,14 @@ apply plugin: 'flow-gradle-plugin'
 
 task wrapper(type: Wrapper) { gradleVersion = '2.3' }
 
+configurations {
+	// Configuration for the jar files we want
+	// to include in the plugin jar
+	includeInPluginJar
+}
+
 dependencies {
+	includeInPluginJar 'com.amazonaws:aws-java-sdk-ec2:1.9.33'
 	testCompile 'junit:junit:[4,)'
 	testCompile 'org.mockito:mockito-core:1.9.5'
 	testCompile 'com.amazonaws:aws-java-sdk-ec2:1.9.33'
@@ -42,6 +49,13 @@ test {
 		events 'started', 'passed'
 		exceptionFormat = 'full'
 	}
+}
+
+// Include any dependent jars in the plugin jar file for
+// evaluating the validation and dynamic option scripts
+// on the ElectricFlow server.
+jar {
+	from(configurations.includeInPluginJar, { into('libs') })
 }
 
 gwt { modules 'ecplugins.ec2.ConfigurationManagement' }

--- a/src/main/resources/project/project.xml
+++ b/src/main/resources/project/project.xml
@@ -220,7 +220,12 @@
                     </property>
                 </propertySheet>
             </property>
-
+            <property>
+                <propertyName>ec_dsl_libraries_path</propertyName>
+                <description>Path where the supporting scripts and jars used for evaluating DSL scripts for validation and dynamic options are located. A relative path is considered relative to the plugin's install directory.</description>
+                <expandable>1</expandable>
+                <value>libs</value>
+            </property>
             <property>
                 <propertyName>lib</propertyName>
                 <description/>


### PR DESCRIPTION
…Configuration validation

Added configuration to package the AWS jar with the EC2 plugin.
Added configuration property 'ec_dsl_libraries_path' that will be used
by the validation script for CreateConfiguration. The validation script
is not being added yet, it will be handled in a separate pull request.
