### PR TITLE
ECPRESOURCEAMAZON-180 (Dev) Add the ability to specify commander zone for createdResources in API_RunInstances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ staging
 .settings
 *.iml
 openstack-test.properties
+*.log

--- a/src/main/resources/project/API_Run.pl
+++ b/src/main/resources/project/API_Run.pl
@@ -2463,6 +2463,8 @@ sub API_RunInstance {
         $opts->{pdb}->setProp( "$propResult/Count",        $count );
     }
 
+    exit 1 if !$resource_zone;
+
     exit 0;
 }
 
@@ -2553,6 +2555,8 @@ sub MOCK_API_RunInstance {
         $opts->{pdb}->setProp( "$propResult/Count",        $count );
     }
 
+    exit 1 if !$resource_zone;
+
     exit 0;
 }
 
@@ -2567,7 +2571,7 @@ sub makeNewResource() {
 
     if (!$zone) {
         mesg( 1, "\nError: No resource zone provided to makeNewResource.\n" );
-        exit 1;
+        return "";
     }
 
    # workspace and port can be blank


### PR DESCRIPTION
Result location property is created even when the resource zone was not specified.
