### PR TITLE
CEV-9187 - Flag to disable formal parameters validations and dynamic options APIs

### DIFF
--- a/src/main/resources/project/ec_setup.pl
+++ b/src/main/resources/project/ec_setup.pl
@@ -374,6 +374,38 @@ if (compareMinor($serverVersion, '6.1') >= 0) {
   $commander->modifyProperty("/projects/$pluginName/procedures/API_RunInstances/ec_form/validation", {credentialProtected => "1"});
   $commander->modifyProperty("/projects/$pluginName/procedures/API_RunInstances/ec_form/parameterOptions", {credentialProtected => "1"});
 
+  if ($upgradeAction eq 'upgrade') {
+    # If the disable flags were set on the earlier version of the plugin,
+    # then set them when upgrading.
+    my $batch = $commander->newBatch();
+    my @reqIds = (
+        $batch->getProperty("/plugins/$otherPluginName/project/ec_disable_dynamic_operations"),
+        $batch->getProperty("/plugins/$otherPluginName/project/procedures/CreateConfiguration/ec_form/disable"),
+        $batch->getProperty("/plugins/$otherPluginName/project/procedures/API_RunInstances/ec_form/disable"),
+    );
+    $batch->submit();
+
+    my $disabledOps = $batch->findvalue($reqIds[0], 'property/value')->string_value();
+    my $disabledCreateConfigurationOp = $batch->findvalue($reqIds[1], 'property/value')->string_value();
+    my $disabledRunInstancesOp = $batch->findvalue($reqIds[2], 'property/value')->string_value();
+
+    if ($disabledOps == '1') {
+        my $desc = $batch->findvalue($reqIds[0], 'property/description');
+        $commander->setProperty( "/plugins/$pluginName/project/ec_disable_dynamic_operations", { value => '1', description => $desc});
+    }
+
+    if ($disabledCreateConfigurationOp == '1') {
+        my $desc = $batch->findvalue($reqIds[1], 'property/description');
+        $commander->setProperty( "/plugins/$pluginName/project/procedures/CreateConfiguration/ec_form/disable", { value => '1', description => $desc});
+    }
+
+    if ($disabledRunInstancesOp == '1') {
+        my $desc = $batch->findvalue($reqIds[2], 'property/description');
+        $commander->setProperty( "/plugins/$pluginName/project/procedures/API_RunInstances/ec_form/disable", { value => '1', description => $desc});
+    }
+
+  }
+
 }
 	
 	

--- a/src/main/resources/project/project.xml
+++ b/src/main/resources/project/project.xml
@@ -231,6 +231,11 @@
                 <value>ec2_cfgs</value>
             </property>
             <property>
+                <propertyName>ec_disable_dynamic_operations</propertyName>
+                <description>Set to '1' if the server-side validations and dynamic options retrieval need to be disabled in Dynamic Environments for this plugin.</description>
+                <value>0</value>
+            </property>
+            <property>
                 <propertyName>lib</propertyName>
                 <description/>
                 <propertySheet>


### PR DESCRIPTION
Added flags to support disabling the validation and dynamic options APIs for the EC2 plugin.
