### PR TITLE
Fixes for ECPRESOURCEAMAZON-196 & ECPRESOURCEAMAZON-197

### DIFF
--- a/src/main/resources/project/manifest.xml
+++ b/src/main/resources/project/manifest.xml
@@ -1769,10 +1769,6 @@
     <xpath>//procedure[procedureName=&quot;API_RunInstances&quot;]/propertySheet/property[propertyName=&quot;ec_form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;resource_zone&quot;]/value</xpath>
   </file>
   <file>
-    <path>procedures/form_scripts/parameterOptions/resources.groovy</path>
-    <xpath>//procedure[procedureName=&quot;API_RunInstances&quot;]/propertySheet/property[propertyName=&quot;ec_form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;res_poolname&quot;]/value</xpath>
-  </file>
-  <file>
     <path>procedures/form_scripts/parameterOptions/workspaces.groovy</path>
     <xpath>//procedure[procedureName=&quot;API_RunInstances&quot;]/propertySheet/property[propertyName=&quot;ec_form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;res_workspace&quot;]/value</xpath>
   </file>

--- a/src/main/resources/project/procedures/form_scripts/validation/ec2Validations.groovy
+++ b/src/main/resources/project/procedures/form_scripts/validation/ec2Validations.groovy
@@ -65,7 +65,7 @@ def doValidations(args) {
 	System.setProperty("com.amazonaws.sdk.disableCertChecking", "true")
 
 	try {
-		def ec2 = login(credential, args.configurationParameters[SERVICE_URL])
+		def ec2 = loginEC2(credential, args.configurationParameters[SERVICE_URL])
 		def privateIp = parameters[PRIVATE_IP]
 		def subnetId = parameters[SUBNET_ID]
 
@@ -79,7 +79,7 @@ def doValidations(args) {
 	result
 }
 
-def login(credential, serviceURL) {
+def loginEC2(credential, serviceURL) {
 	// Disable HTTPS certificate verification
 	System.setProperty("com.amazonaws.sdk.disableCertChecking", "true")
 

--- a/src/main/resources/project/project.xml
+++ b/src/main/resources/project/project.xml
@@ -6844,11 +6844,6 @@
                                     <value/>
                                 </property>
                                 <property>
-                                    <propertyName>res_poolname</propertyName>
-                                    <expandable>1</expandable>
-                                    <value/>
-                                </property>
-                                <property>
                                     <propertyName>res_workspace</propertyName>
                                     <expandable>1</expandable>
                                     <value/>

--- a/src/main/resources/project/ui_forms/API_RunInstances.xml
+++ b/src/main/resources/project/ui_forms/API_RunInstances.xml
@@ -196,8 +196,14 @@
         <label>Resource Pool:</label>
         <property>res_poolName</property>
         <required>0</required>
-        <serverOptions>1</serverOptions>
         <documentation>If you would like to add Commander resources for each instance created, enter the Commander pool name for the new resource. If left blank no resource will be created.</documentation>
+    </formElement>
+    <formElement>
+        <type>entry</type>
+        <label>Resource port:</label>
+        <property>res_port</property>
+        <required>0</required>
+        <documentation>If you specify a resource pool name in 'Resource Pool' field, this is the port that will be used when creating the resource. If no value is specified, port 7800 will be used by default when creating the resource.</documentation>
     </formElement>
     <formElement>
         <type>entry</type>
@@ -205,14 +211,7 @@
         <property>res_workspace</property>
         <required>0</required>
         <serverOptions>1</serverOptions>
-        <documentation>If you specify a resource pool name in res_poolName, this is the workspace that will be used when creating the resource.</documentation>
-    </formElement>
-    <formElement>
-        <type>entry</type>
-        <label>Resource port:</label>
-        <property>res_port</property>
-        <required>0</required>
-        <documentation>If you specify a resource pool name in res_poolName, this is the port that will be used when creating the resource. If no value is specified, port 7800 will be used by default when creating the resource.</documentation>
+        <documentation>If you specify a resource pool name in 'Resource Pool' field, this is the workspace that will be used when creating the resource.</documentation>
     </formElement>
 	<formElement>
         <label>Resource Zone Name:</label>

--- a/src/test/groovy/ecplugins/ec2/BaseScriptsTestCase.groovy
+++ b/src/test/groovy/ecplugins/ec2/BaseScriptsTestCase.groovy
@@ -4,7 +4,7 @@ import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import groovy.util.GroovyShellTestCase
 
-public class BaseScriptsTestCase extends GroovyShellTestCase {
+abstract public class BaseScriptsTestCase extends GroovyShellTestCase {
 
 	protected ResourceBundle testProperties;
 

--- a/src/test/groovy/ecplugins/ec2/EC2ValidationsTest.groovy
+++ b/src/test/groovy/ecplugins/ec2/EC2ValidationsTest.groovy
@@ -7,17 +7,23 @@ class EC2ValidationsTest extends BaseScriptsTestCase {
 	def SCRIPT = 'project/procedures/form_scripts/validation/ec2Validations.groovy'
 	def json = new JsonBuilder()
 	def subnetId = 'subnet-be3293db'
+	def credential
+	def configurationParams
 
-	def credential = json (
-	credentialName: 'testCredential',
-	userName: testProperties.getString(PROP_AWS_KEY_ID),
-	password: testProperties.getString(PROP_AWS_KEY)
-	)
+	@Override
+	void setUp() {
+		super.setUp()
 
-	def configurationParams = json (
-	service_url : testProperties.getString(PROP_SVC_URL)
-	)
+		credential = json (
+				credentialName: 'testCredential',
+				userName: testProperties.getString(PROP_AWS_KEY_ID),
+				password: testProperties.getString(PROP_AWS_KEY)
+				)
 
+		configurationParams = json (
+				service_url : testProperties.getString(PROP_SVC_URL)
+				)
+	}
 
 	void testIpNotInSubnetRange() {
 


### PR DESCRIPTION
ECPRESOURCEAMAZON-197 Server throws "At line 76: InvalidCredentials:
Invalid user 'https://ec2.us-west-2.amazonaws.com' or incorrect
password" if user provided not not valid "Private IP" address

ECPRESOURCEAMAZON-196 'Resource Pool' in the Cloud provider 'Provision
parameters' should not be a drop-down

Fixed unit tests for dynamic parameter options.
